### PR TITLE
fixed sum and product function logic

### DIFF
--- a/arrayfire/library/vector_algorithms.py
+++ b/arrayfire/library/vector_algorithms.py
@@ -206,10 +206,10 @@ def sum(array: Array, /, *, axis: int | None = None, nan_value: float | None = N
 
         return wrapper.sum_nan_all(array.arr, nan_value)
 
-    if nan_value is not None:
-        return Array.from_afarray(wrapper.sum_nan(array.arr, axis, nan_value))
+    if nan_value is None:
+        return Array.from_afarray(wrapper.sum(array.arr, axis))
 
-    return Array.from_afarray(wrapper.sum(array.arr, axis))  # type: ignore[call-arg]
+    return Array.from_afarray(wrapper.sum_nan(array.arr, axis, nan_value))  # type: ignore[call-arg]
 
 
 def product(

--- a/arrayfire/library/vector_algorithms.py
+++ b/arrayfire/library/vector_algorithms.py
@@ -207,9 +207,9 @@ def sum(array: Array, /, *, axis: int | None = None, nan_value: float | None = N
         return wrapper.sum_nan_all(array.arr, nan_value)
 
     if nan_value is not None:
-        return Array.from_afarray(wrapper.sum(array.arr, axis))
+        return Array.from_afarray(wrapper.sum_nan(array.arr, axis, nan_value))
 
-    return Array.from_afarray(wrapper.sum_nan(array.arr, axis, nan_value=nan_value))  # type: ignore[call-arg]
+    return Array.from_afarray(wrapper.sum(array.arr, axis))  # type: ignore[call-arg]
 
 
 def product(
@@ -247,7 +247,7 @@ def product(
     if nan_value is None:
         return Array.from_afarray(wrapper.product(array.arr, axis))
 
-    return Array.from_afarray(wrapper.product_nan(array.arr, axis, nan_value=nan_value))  # type: ignore[call-arg]
+    return Array.from_afarray(wrapper.product_nan(array.arr, axis, nan_value))  # type: ignore[call-arg]
 
 
 def count(


### PR DESCRIPTION
This PR implements a refinement in the handling of nan values within the sum and product functions of the vector_algorithms.py file in the ArrayFire Python library.

The original logic erroneously assigned a default nan value in scenarios where a None value was present, and also incorrectly set the nan_value even when it was not explicitly provided by the user. This update corrects these behaviors, ensuring that the functions operate as intended and enhancing the robustness of the library's numerical computations.






